### PR TITLE
Rework the internals

### DIFF
--- a/hypothesis_networkx/strategy.py
+++ b/hypothesis_networkx/strategy.py
@@ -39,24 +39,24 @@ def graph_builder(draw,
     ----------
     draw
         For internal hypothesis use.
-    node_data: `hypothesis.Strategy`
+    node_data: `hypothesis.SearchStrategy[dict]`
         The strategy to use to generate node attributes. Must generate a
         mapping.
-    edge_data: `hypothesis.Strategy`
+    edge_data: `hypothesis.SearchStrategy[dict]`
         The strategy to use to generate edge attributes. Must generate a
         mapping.
-    node_keys: `hypothesis.Strategy` or None.
+    node_keys: `hypothesis.SearchStrategy[collections.abc.Hashable]` or None
         The strategy to use to generate node keys. Must generate a Hashable. If
         `None`, node keys will be taken from range(0, number_of_nodes).
     min_nodes: int
         The minimum number of nodes that should be in the generated graph. Must
         be positive.
-    max_nodes: int
+    max_nodes: int or None
         The maximum number of nodes that should be in the generated graph. Must
         be larger than `min_nodes`. `None` means no upper limit.
     min_edges: int
         The minimum number of edges that should be in the generated graph.
-    max_edges: int
+    max_edges: int or None
         The maximum number of edges that should be in the generated graph.
         `None` means no upper limit.
     graph_type: class
@@ -64,8 +64,8 @@ def graph_builder(draw,
     self_loops: bool
         Whether self loops (edges between a node and itself) are allowed.
     connected: bool
-        If `True`, the generated graph is guaranteed to be a single connected
-        component.
+        If `True`, the generated graph is guaranteed to be a single (weakly)
+        connected component.
 
     Raises
     ------

--- a/hypothesis_networkx/strategy.py
+++ b/hypothesis_networkx/strategy.py
@@ -169,7 +169,7 @@ def graph_builder(draw,
                          unique_by=None if isinstance(graph, nx.MultiGraph) else lambda e: e[:-1],
                          min_size=min_edges,
                          max_size=max_edges)
-        graph.add_edges_from((*e[0], e[1]) for e in draw(edges))
+        graph.add_edges_from((e[0][0], e[0][1], e[1]) for e in draw(edges))
 
     if node_keys is not None:
         new_idxs = draw(st.lists(node_keys,

--- a/hypothesis_networkx/strategy.py
+++ b/hypothesis_networkx/strategy.py
@@ -90,6 +90,9 @@ def graph_builder(draw,
                          "nodes with less than {} edges".format(max_nodes, max_nodes-1))
 
     graph = graph_type()
+
+    is_multigraph = graph.is_multigraph()
+    is_directed = graph.is_directed()
     # Draw node indices and their associated data
     node_datas = draw(st.lists(node_data, min_size=min_nodes, max_size=max_nodes))
 
@@ -103,44 +106,43 @@ def graph_builder(draw,
     # edge between n_idx and one of those before so that all nodes < n_idx + 1
     # are now connected.
     if connected:
-        initial_edges = [draw(st.tuples(st.sampled_from(range(0, n_idx)),
+        # Shrink towards high index, so shrink to the path graph. Otherwise
+        # it'll shrink to the star graph.
+        initial_edges = [draw(st.tuples(st.integers(-(n_idx-1), 0).map(lambda x: -x),
                                         st.just(n_idx),
                                         edge_data))
                          for n_idx in range(1, len(graph))]
         graph.add_edges_from(initial_edges)
 
+    def edge_filter(idx, jdx):
+        """
+        Helper function to decide whether the edge between idx and jdx can still
+        be added to graph.
+        """
+        # <= because self loops
+        return ((not graph.has_edge(idx, jdx) or is_multigraph) and
+                (idx <= jdx or is_directed) and
+                (idx != jdx or self_loops))
+
+    available_edges = [(idx, jdx) for jdx in graph for idx in graph
+                       if edge_filter(idx, jdx)]
+
     # Now for the mess. The maximum number of edges possible depends on the
     # graph type.
-    if isinstance(graph, nx.MultiGraph):
-        # Multi(Di)Graphs can make an infinite number of edges. We'll keep it as
-        # a numeric value for now.
-        max_possible_edges = float('inf')
-    else:
-        # If it's a DiGraph, edge [a, b] != [b, a]; but if it's an undirected
-        # graph [a, b] == [b, a]. It becomes slightly worse, since DiGraph is a
-        # subclass of Graph.
-        if isinstance(graph, nx.DiGraph):
-            max_possible_edges = len(graph) * (len(graph) - 1)
-        else:  # elif isinstance(graph, nx.Graph):
-            max_possible_edges = (len(graph) * (len(graph) - 1))//2
-        # And if we can make self-loops we get a few more. Note that the edge
-        # (1, 1) is the same as the edge (1, 1), even in a DiGraph.
-        if self_loops:
-            max_possible_edges += len(graph)
+    if max_edges is not None:
+        # Correct for number of edges already made if graph is connected.
+        # This may mean we added more edges than originally allowed.
+        max_edges -= len(graph.edges)
+    if not is_multigraph:
+        # Multi(Di)Graphs can make an infinite number of edges. For everything
+        # else we clamp the range to (0, max_possible_edges)
+        max_possible_edges = len(available_edges)
+        if max_edges is None or max_edges > max_possible_edges:
+            max_edges = max_possible_edges
+    if max_edges < 0:
+        max_edges = 0
 
-    # Clamp to the range (0, max_possible_edges). Note that max_possible_edges
-    # may be infinite in the case of MultiGraphs.
-    if max_edges is None or max_edges > max_possible_edges:
-        max_edges = max_possible_edges
-    elif max_edges < 0:
-        # We will need to correct for the number of edges already added.
-        max_edges = len(graph.edges)
-    max_edges -= len(graph.edges)
-
-    if max_edges == float('inf'):
-        max_edges = None
-
-    # Likewise for min_edges...
+    # Likewise for min_edges
     # We already added some edges, so subtract those.
     min_edges -= len(graph.edges)
     if min_edges < 0:
@@ -148,28 +150,29 @@ def graph_builder(draw,
     elif min_edges > max_edges:
         min_edges = max_edges
 
-    def edge_filter(idx, jdx):
-        """
-        Helper function to decide whether the edge between idx and jdx can still
-        be added to graph.
-        """
-        multi_edge = not graph.has_edge(idx, jdx) or isinstance(graph, nx.MultiGraph)
-        # <= because self loops
-        directed = idx <= jdx or isinstance(graph, nx.DiGraph)
-        self_loop = idx != jdx or self_loops
-        return multi_edge and directed and self_loop
-
-    options = [(idx, jdx) for jdx in graph for idx in graph if edge_filter(idx, jdx)]
-    if options:
-        # We need to sample a number of items from options, these items are 
-        # possibly not unique. In addition, we need to draw the same number of
-        # items from edge_data and associate the two. To top it off, uniqueness
-        # is defined by the content of the first element of the tuple.
-        edges = st.lists(st.tuples(st.sampled_from(options), edge_data),
-                         unique_by=None if isinstance(graph, nx.MultiGraph) else lambda e: e[:-1],
+    # We need to sample a number of items from options, these items are 
+    # possibly not unique. In addition, we need to draw the same number of
+    # items from edge_data and associate the two. To top it off, uniqueness
+    # is defined by the content of the first element of the tuple.
+    if is_multigraph:
+        # This is the recommended way because it shrinks better, but it is
+        # prohibitively slow if too many of the available edge have to be drawn,
+        # and they need to be unique.
+        # See https://github.com/HypothesisWorks/hypothesis/issues/1887
+        edges = st.lists(st.tuples(st.sampled_from(available_edges), edge_data),
+                         # unique_by=None if is_multigraph else lambda e: e[:-1],
                          min_size=min_edges,
                          max_size=max_edges)
         graph.add_edges_from((e[0][0], e[0][1], e[1]) for e in draw(edges))
+    else:
+        # Not the recommended way, but way faster if edges have to be unique
+        # Based on https://github.com/HypothesisWorks/hypothesis/issues/1393#issuecomment-409505039
+        edges = []
+        for _ in range(draw(st.integers(min_edges, max_edges))):
+            idx, jdx = draw(st.sampled_from(available_edges))
+            available_edges.remove((idx, jdx))
+            edges.append((idx, jdx, draw(edge_data)))
+        graph.add_edges_from(edges)
 
     if node_keys is not None:
         new_idxs = draw(st.lists(node_keys,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -14,23 +14,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from hypothesis_networkx import graph_builder
+"""
+These tests make sure the appropriate errors get raised.
+"""
 import pytest
 
+from hypothesis_networkx import graph_builder
+
+# Pylint doesn't like hypothesis
+# pylint: disable=no-member, no-value-for-parameter
 
 def test_min_nodes():
+    """
+    Make sure min_nodes is positive.
+    """
     builder = graph_builder(min_nodes=-5)
     with pytest.raises(ValueError):
         builder.example()
 
 
 def test_min_max_nodes():
+    """
+    Make sure min_nodes <= max_nodes
+    """
     builder = graph_builder(min_nodes=10, max_nodes=5)
     with pytest.raises(ValueError):
         builder.example()
 
 
 def test_max_edges():
+    """
+    Make sure that max_edges is large enough to not conflict with connected=True
+    """
     builder = graph_builder(max_nodes=5, connected=True, max_edges=2)
     with pytest.raises(ValueError):
         builder.example()

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -14,11 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from hypothesis_networkx import graph_builder
 
 from hypothesis import strategies as st
 from hypothesis import given, settings, HealthCheck, note
+
 import networkx as nx
+
+from hypothesis_networkx import graph_builder
+
+# Pylint doesn't like hypothesis
+# pylint: disable=no-value-for-parameter
 
 
 @settings(max_examples=250, suppress_health_check=[HealthCheck.too_slow])

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -36,14 +36,22 @@ def test_graph_builder(data):
     graph_type = data.draw(graph_types, label='graph type')
     node_keys = st.integers()
 
-    min_nodes = data.draw(st.integers(min_value=0, max_value=15),
+    multigraph = graph_type in [nx.MultiGraph, nx.MultiDiGraph,
+                                nx.OrderedMultiGraph, nx.OrderedMultiDiGraph]
+
+    min_nodes = data.draw(st.integers(min_value=0, max_value=25),
                           label='min nodes')
-    max_nodes = data.draw(st.integers(min_value=min_nodes, max_value=15),
+    max_nodes = data.draw(st.integers(min_value=min_nodes, max_value=25),
                           label='max nodes')
 
-    min_edges = data.draw(st.integers(min_value=0), label='min edges')
+    max_min_edges = None if not multigraph else 50
+    min_edges = data.draw(st.integers(min_value=0, max_value=max_min_edges),
+                          label='min edges')
     max_edges = data.draw(st.one_of(st.none(), st.integers(min_value=max(min_edges, max_nodes-1))),
                           label='max edges')
+
+    if multigraph:
+        max_edges = min(50, max_edges) if max_edges else 50
 
     self_loops = data.draw(st.booleans(), label='self loops')
     connected = data.draw(st.booleans(), label='connected')
@@ -115,6 +123,21 @@ def test_node_edge_data(data):
         assert graph.nodes[node] == node_data
     for edge in graph.edges:
         assert graph.edges[edge] == edge_data
+
+
+@given(st.data())
+def test_node_keys(data):
+    """
+    Make sure node keys are drawn from the correct strategy.
+    """
+    size = 5
+    base_keys = st.one_of(st.integers(), st.text())
+    node_keys = st.sets(st.recursive(base_keys, lambda s: st.tuples(s, s)),
+                        min_size=size, max_size=size)
+    keys = data.draw(node_keys)
+    graph = data.draw(graph_builder(min_nodes=size, max_nodes=size,
+                                    node_keys=st.sampled_from(list(keys))))
+    assert set(graph.nodes) == set(keys)
 
 
 @given(st.data())


### PR DESCRIPTION
Following the nice guide https://github.com/HypothesisWorks/hypothesis/blob/51b59658a10aaa653fe1806e53c873702a5e1a99/guides/strategies-that-shrink.rst there appears to be better ways to make strategies that shrink nice. This is the result.
In addition, added the option for `node_keys=None`, in which node keys are drawn from the `range(0, number_of_nodes)`