### PR TITLE
Handle the case is_multigraph and max_edges is None

### DIFF
--- a/hypothesis_networkx/strategy.py
+++ b/hypothesis_networkx/strategy.py
@@ -131,15 +131,15 @@ def graph_builder(draw,
         # Correct for number of edges already made if graph is connected.
         # This may mean we added more edges than originally allowed.
         max_edges -= len(graph.edges)
-    if max_edges < 0:
-        max_edges = 0
+        if max_edges < 0:
+            max_edges = 0
 
     # Likewise for min_edges
     # We already added some edges, so subtract those.
     min_edges -= len(graph.edges)
     if min_edges < 0:
         min_edges = 0
-    elif min_edges > max_edges:
+    elif max_edges is not None and min_edges > max_edges:
         min_edges = max_edges
 
     def edge_filter(edge):

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -103,6 +103,13 @@ def test_graph_builder(data):
             assert not connected or nx.is_connected(graph)
 
 
+def test_multigraph_max_edges_none():
+    try:
+        graph_builder(graph_type=nx.MultiGraph, max_edges=None).example()
+    except Exception:
+        pytest.fail()
+
+
 @settings(deadline=None)
 @given(st.data())
 def test_node_edge_data(data):


### PR DESCRIPTION
I noticed that passing a multigraph `graph_type` with the default value of `max_edges=None` raises a `TypeError` due to attempting to compare `None` with various integers. I could have modified `tests/test_graph_builder.py::test_graph_builder` to cover this case, but I assumed y'all had the upper limit of 50 edges for a reason, so I added a separate test that just asserts that no exception is raised for `graph_type=nx.MultiGraph, max_edges=None`.